### PR TITLE
fix: タイムゾーンに依存しないテストの実装

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nagopy/kmp/habittracker/domain/usecase/GetNextTasksUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/nagopy/kmp/habittracker/domain/usecase/GetNextTasksUseCase.kt
@@ -21,7 +21,8 @@ import kotlinx.datetime.toLocalDateTime
  */
 class GetNextTasksUseCase(
     private val habitRepository: HabitRepository,
-    private val clock: Clock = Clock.System
+    private val clock: Clock = Clock.System,
+    private val timeZone: TimeZone = TimeZone.currentSystemDefault()
 ) {
     
     /**
@@ -34,7 +35,7 @@ class GetNextTasksUseCase(
         val habit = habitRepository.getHabit(habitId) ?: return null
         if (!habit.isActive) return null
         
-        val currentDateTime = clock.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        val currentDateTime = clock.now().toLocalDateTime(timeZone)
         val today = currentDateTime.date
         
         // Look for tasks today and tomorrow to find the next one
@@ -59,7 +60,7 @@ class GetNextTasksUseCase(
      */
     suspend fun getNextUpcomingTask(): Task? {
         val habits = habitRepository.getActiveHabits().first()
-        val currentDateTime = clock.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        val currentDateTime = clock.now().toLocalDateTime(timeZone)
         
         var nextTask: Task? = null
         var nextTaskDateTime: LocalDateTime? = null

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/domain/usecase/GetNextTasksUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/domain/usecase/GetNextTasksUseCaseTest.kt
@@ -10,8 +10,10 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -24,14 +26,18 @@ class GetNextTasksUseCaseTest {
     
     private val getNextTasksUseCase = GetNextTasksUseCase(
         habitRepository = mockHabitRepository,
-        clock = mockClock
+        clock = mockClock,
+        timeZone = TimeZone.UTC
     )
 
     @Test
     fun `getNextTaskForHabit should return next upcoming task`() = runTest {
         // Given
         val habitId = 1L
-        val currentTime = Instant.parse("2024-01-20T10:30:00Z")
+        // Create a specific LocalDateTime that represents 10:30 AM on 2024-01-20
+        // Convert to Instant using UTC to avoid timezone issues in test
+        val currentLocalDateTime = LocalDateTime(2024, 1, 20, 10, 30)
+        val currentTime = currentLocalDateTime.toInstant(TimeZone.UTC)
         val habit = Habit(
             id = habitId,
             name = "Test Habit",
@@ -62,7 +68,8 @@ class GetNextTasksUseCaseTest {
     fun `getNextTaskForHabit should return null for inactive habit`() = runTest {
         // Given
         val habitId = 1L
-        val currentTime = Instant.parse("2024-01-20T10:30:00Z")
+        val currentLocalDateTime = LocalDateTime(2024, 1, 20, 10, 30)
+        val currentTime = currentLocalDateTime.toInstant(TimeZone.UTC)
         val habit = Habit(
             id = habitId,
             name = "Test Habit",
@@ -90,7 +97,8 @@ class GetNextTasksUseCaseTest {
     fun `getNextTaskForHabit should return null when habit not found`() = runTest {
         // Given
         val habitId = 1L
-        val currentTime = Instant.parse("2024-01-20T10:30:00Z")
+        val currentLocalDateTime = LocalDateTime(2024, 1, 20, 10, 30)
+        val currentTime = currentLocalDateTime.toInstant(TimeZone.UTC)
         
         coEvery { mockClock.now() } returns currentTime
         coEvery { mockHabitRepository.getHabit(habitId) } returns null
@@ -105,7 +113,8 @@ class GetNextTasksUseCaseTest {
     @Test
     fun `getNextUpcomingTask should return earliest task across all habits`() = runTest {
         // Given
-        val currentTime = Instant.parse("2024-01-20T10:30:00Z")
+        val currentLocalDateTime = LocalDateTime(2024, 1, 20, 10, 30)
+        val currentTime = currentLocalDateTime.toInstant(TimeZone.UTC)
         val habit1 = Habit(
             id = 1L,
             name = "Habit 1",
@@ -149,7 +158,8 @@ class GetNextTasksUseCaseTest {
     @Test
     fun `getNextUpcomingTask should return null when no active habits`() = runTest {
         // Given
-        val currentTime = Instant.parse("2024-01-20T10:30:00Z")
+        val currentLocalDateTime = LocalDateTime(2024, 1, 20, 10, 30)
+        val currentTime = currentLocalDateTime.toInstant(TimeZone.UTC)
         
         coEvery { mockClock.now() } returns currentTime
         coEvery { mockHabitRepository.getActiveHabits() } returns flowOf(emptyList())


### PR DESCRIPTION
GetNextTasksUseCaseTestでタイムゾーンによる失敗を修正:
- GetNextTasksUseCaseにtimeZoneパラメータを追加して依存性注入を可能に
- テストでTimeZone.UTCを固定使用することでタイムゾーン依存を排除
- LocalDateTimeからInstantへの変換を明示的に制御
- Asia/TokyoやUTCなど任意のタイムゾーンで安定したテスト実行を実現

🤖 Generated with [Claude Code](https://claude.ai/code)