### PR TITLE
fix: 時刻解析失敗時にログ出力を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapper.kt
@@ -7,6 +7,7 @@ import com.nagopy.kmp.habittracker.domain.model.HabitDetail
 import com.nagopy.kmp.habittracker.domain.model.HabitLog
 import com.nagopy.kmp.habittracker.domain.model.FrequencyType
 import com.nagopy.kmp.habittracker.domain.model.HabitIntervalValidator
+import com.nagopy.kmp.habittracker.util.Logger
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 
@@ -86,6 +87,7 @@ private fun parseScheduledTimes(timesString: String): List<LocalTime> {
                     LocalTime(parts[0].toInt(), parts[1].toInt())
                 } else null
             } catch (e: Exception) {
+                Logger.e(e, "Failed to parse time")
                 null
             }
         }.ifEmpty { listOf(LocalTime(9, 0)) }
@@ -105,6 +107,7 @@ private fun parseTime(timeString: String): LocalTime? {
             LocalTime(parts[0].toInt(), parts[1].toInt())
         } else null
     } catch (e: Exception) {
+        Logger.e(e, "Failed to parse time")
         null
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapper.kt
@@ -87,7 +87,7 @@ private fun parseScheduledTimes(timesString: String): List<LocalTime> {
                     LocalTime(parts[0].toInt(), parts[1].toInt())
                 } else null
             } catch (e: Exception) {
-                Logger.e(e, "Failed to parse time")
+                Logger.e(e, "Failed to parse time", tag = "HabitMapper")
                 null
             }
         }.ifEmpty { listOf(LocalTime(9, 0)) }
@@ -107,7 +107,7 @@ private fun parseTime(timeString: String): LocalTime? {
             LocalTime(parts[0].toInt(), parts[1].toInt())
         } else null
     } catch (e: Exception) {
-        Logger.e(e, "Failed to parse time")
+        Logger.e(e, "Failed to parse time", tag = "HabitMapper")
         null
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
@@ -416,7 +416,9 @@ class HabitMapperTest {
 
         entity.toDomainModel()
 
-        val logged = TestAntilog.logs.any { it.contains("Failed to parse time") }
+        val logged = TestAntilog.logs.any { 
+            it.contains("Failed to parse time") && it.contains("[HabitMapper]")
+        }
         assertTrue(logged)
     }
 
@@ -437,7 +439,9 @@ class HabitMapperTest {
 
         entity.toDomainModel()
 
-        val logged = TestAntilog.logs.any { it.contains("Failed to parse time") }
+        val logged = TestAntilog.logs.any { 
+            it.contains("Failed to parse time") && it.contains("[HabitMapper]")
+        }
         assertTrue(logged)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
@@ -9,6 +9,8 @@ import com.nagopy.kmp.habittracker.domain.model.HabitDetail
 import com.nagopy.kmp.habittracker.domain.model.frequencyType
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
+import com.nagopy.kmp.habittracker.util.TestLoggerConfig
+import com.nagopy.kmp.habittracker.util.TestAntilog
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -385,5 +387,49 @@ class HabitMapperTest {
             assertEquals(LocalTime(9, 0), it.startTime) // INTERVAL uses startTime
             assertEquals(null, it.endTime) // INTERVAL can have no end time
         }
+    }
+
+    @Test
+    fun `parseScheduledTimes should log error on malformed time`() {
+        TestLoggerConfig.setupForTests()
+        val entity = HabitEntity(
+            id = 1,
+            name = "Test",
+            description = "",
+            color = "#FFFFFF",
+            isActive = true,
+            createdAt = "2024-01-01",
+            intervalMinutes = 1440,
+            scheduledTimes = "invalid"
+        )
+
+        entity.toDomainModel()
+
+        val logged = TestAntilog.logs.any { it.contains("Failed to parse time") }
+        TestLoggerConfig.tearDown()
+        assertTrue(logged)
+    }
+
+    @Test
+    fun `parseTime should log error on malformed start time`() {
+        TestLoggerConfig.setupForTests()
+        val entity = HabitEntity(
+            id = 1,
+            name = "Water",
+            description = "",
+            color = "#FFFFFF",
+            isActive = true,
+            createdAt = "2024-01-01",
+            intervalMinutes = 60,
+            scheduledTimes = "",
+            startTime = "invalid",
+            endTime = null
+        )
+
+        entity.toDomainModel()
+
+        val logged = TestAntilog.logs.any { it.contains("Failed to parse time") }
+        TestLoggerConfig.tearDown()
+        assertTrue(logged)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
@@ -11,11 +11,23 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import com.nagopy.kmp.habittracker.util.TestLoggerConfig
 import com.nagopy.kmp.habittracker.util.TestAntilog
+import kotlin.test.BeforeTest
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class HabitMapperTest {
+
+    @BeforeTest
+    fun setup() {
+        TestLoggerConfig.setupForTests()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        TestLoggerConfig.tearDown()
+    }
 
     @Test
     fun `HabitEntity toDomainModel should map correctly`() {
@@ -391,7 +403,6 @@ class HabitMapperTest {
 
     @Test
     fun `parseScheduledTimes should log error on malformed time`() {
-        TestLoggerConfig.setupForTests()
         val entity = HabitEntity(
             id = 1,
             name = "Test",
@@ -406,13 +417,11 @@ class HabitMapperTest {
         entity.toDomainModel()
 
         val logged = TestAntilog.logs.any { it.contains("Failed to parse time") }
-        TestLoggerConfig.tearDown()
         assertTrue(logged)
     }
 
     @Test
     fun `parseTime should log error on malformed start time`() {
-        TestLoggerConfig.setupForTests()
         val entity = HabitEntity(
             id = 1,
             name = "Water",
@@ -429,7 +438,6 @@ class HabitMapperTest {
         entity.toDomainModel()
 
         val logged = TestAntilog.logs.any { it.contains("Failed to parse time") }
-        TestLoggerConfig.tearDown()
         assertTrue(logged)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/data/mapper/HabitMapperTest.kt
@@ -400,7 +400,7 @@ class HabitMapperTest {
             isActive = true,
             createdAt = "2024-01-01",
             intervalMinutes = 1440,
-            scheduledTimes = "invalid"
+            scheduledTimes = "07:xx"
         )
 
         entity.toDomainModel()
@@ -422,7 +422,7 @@ class HabitMapperTest {
             createdAt = "2024-01-01",
             intervalMinutes = 60,
             scheduledTimes = "",
-            startTime = "invalid",
+            startTime = "07:xx",
             endTime = null
         )
 

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/util/TestAntilog.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/util/TestAntilog.kt
@@ -7,10 +7,17 @@ import io.github.aakira.napier.LogLevel
  * Test-specific antilog that doesn't use Android Log to avoid mocking issues in tests
  */
 class TestAntilog : Antilog() {
+    companion object {
+        val logs = mutableListOf<String>()
+        fun clear() = logs.clear()
+    }
+
     override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         // Simple println that works in tests without Android Log
         val tagText = tag?.let { "[$it] " } ?: ""
         val throwableText = throwable?.let { " - ${it.message}" } ?: ""
-        println("${priority.name}: $tagText$message$throwableText")
+        val log = "${priority.name}: $tagText$message$throwableText"
+        println(log)
+        logs += log
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/util/TestLoggerConfig.kt
+++ b/composeApp/src/commonTest/kotlin/com/nagopy/kmp/habittracker/util/TestLoggerConfig.kt
@@ -12,6 +12,7 @@ object TestLoggerConfig {
      * This should be called in test setup to avoid Android Log mocking issues
      */
     fun setupForTests() {
+        TestAntilog.clear()
         Napier.base(TestAntilog())
     }
     


### PR DESCRIPTION
## Summary
- parseScheduledTimes/parseTime が失敗した際に Logger.e を呼び出すよう修正
- TestAntilog にログ保存機能を追加し、TestLoggerConfig で初期化時にクリア
- HabitMapperTest にログ出力を検証するテストを追加

## Testing
- `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca1ecf5ec832abfbd9c0035ecb83a